### PR TITLE
Use categoryGroup for AFW logs

### DIFF
--- a/networking/hub-default.json
+++ b/networking/hub-default.json
@@ -560,7 +560,7 @@
             "resources": [
                 {
                     "type": "providers/diagnosticSettings",
-                    "apiVersion": "2017-05-01-preview",
+                    "apiVersion": "2021-05-01-preview",
                     "name": "Microsoft.Insights/default",
                     "dependsOn": [
                         "[resourceId('Microsoft.OperationalInsights/workspaces', variables('hubLaName'))]",
@@ -570,15 +570,7 @@
                         "workspaceId": "[resourceId('Microsoft.OperationalInsights/workspaces', variables('hubLaName'))]",
                         "logs": [
                             {
-                                "category": "AzureFirewallApplicationRule",
-                                "enabled": true
-                            },
-                            {
-                                "category": "AzureFirewallNetworkRule",
-                                "enabled": true
-                            },
-                            {
-                                "category": "AzureFirewallDnsProxy",
+                                "categoryGroup": "allLogs",
                                 "enabled": true
                             }
                         ],

--- a/networking/hub-regionA.json
+++ b/networking/hub-regionA.json
@@ -762,7 +762,7 @@
             "resources": [
                 {
                     "type": "providers/diagnosticSettings",
-                    "apiVersion": "2017-05-01-preview",
+                    "apiVersion": "2021-05-01-preview",
                     "name": "Microsoft.Insights/default",
                     "dependsOn": [
                         "[resourceId('Microsoft.OperationalInsights/workspaces', variables('hubLaName'))]",
@@ -772,15 +772,7 @@
                         "workspaceId": "[resourceId('Microsoft.OperationalInsights/workspaces', variables('hubLaName'))]",
                         "logs": [
                             {
-                                "category": "AzureFirewallApplicationRule",
-                                "enabled": true
-                            },
-                            {
-                                "category": "AzureFirewallNetworkRule",
-                                "enabled": true
-                            },
-                            {
-                                "category": "AzureFirewallDnsProxy",
+                                "categoryGroup": "allLogs",
                                 "enabled": true
                             }
                         ],


### PR DESCRIPTION
Updating the API version on the FW to avoid the `categoryGroup` conflict that might happen on redeployment.