### PR TITLE
Update to latest fluxConfiguration RP API version

### DIFF
--- a/cluster-stamp.json
+++ b/cluster-stamp.json
@@ -1035,7 +1035,7 @@
                 },
                 {
                     "type": "providers/fluxConfigurations",
-                    "apiVersion": "2021-11-01-preview",
+                    "apiVersion": "2022-01-01-preview",
                     "name": "Microsoft.KubernetesConfiguration/bootstrap",
                     "comments": "Bootstraps your cluster using content from your repo.",
                     "dependsOn": [
@@ -1044,7 +1044,7 @@
                         "[resourceId('Microsoft.ContainerService/managedClusters', variables('clusterName'))]"
                     ],
                     "properties": {
-                        "scope": "Cluster",
+                        "scope": "cluster",
                         "namespace": "flux-system",
                         "sourceKind": "GitRepository",
                         "gitRepository": {
@@ -1059,7 +1059,7 @@
                             },
                             "sshKnownHosts": "",
                             "httpsUser": "[null()]",
-                            "httpsCAFile": "[null()]",
+                            "httpsCACert": "[null()]",
                             "localAuthRef": "[null()]"
                         },
                         "kustomizations": {


### PR DESCRIPTION
`httpsCAFile` was renamed to `httpsCACert` in the new API version.  New API version also supports S3 buckets.