### PR TITLE
Mention the requirement to Base64 Encode the PAT

### DIFF
--- a/cluster-manifests/README.md
+++ b/cluster-manifests/README.md
@@ -35,7 +35,7 @@ Use the following pattern in your `fluxConfigurations` extension resource.
             "url": "git@github.com:yourorg/yourrepo.git"
         },
         "configurationProtectedSettings": {
-            "sshPrivateKey": "<Base64 Encoded PEM Private Key>"
+            "sshPrivateKey": "<Base64 encoded PEM private key>"
         }
     }
 }
@@ -54,9 +54,8 @@ You'll use the following pattern in your `fluxConfigurations` extension resource
             "httpsUser": "<Username>"
         },
         "configurationProtectedSettings": {
-            "httpsKey": "<Personal Access Token>"
+            "httpsKey": "<Base64 encoded, UTF-8 encoded Personal Access Token>"
         }
     }
 }
-
 ```


### PR DESCRIPTION
HT to @ngbrown who called out that the instructions for Personal Access Tokens did not mention the requirement to Base64 encode the value (unlike the SSH instructions).  Adding that bit into the snippits.