### PR TITLE
Change nodepoolSubnetResourceIds output to array

### DIFF
--- a/networking/spoke-BU0001A0008.bicep
+++ b/networking/spoke-BU0001A0008.bicep
@@ -356,5 +356,7 @@ resource pipPrimaryClusterIp_diagnosticSetting 'Microsoft.Insights/diagnosticSet
 /*** OUTPUTS ***/
 
 output clusterVnetResourceId string = vnetSpoke.id
-output nodepoolSubnetResourceIds string = '[\'${vnetSpoke::snetClusterNodes.id}\']'
+output nodepoolSubnetResourceIds array = [
+  '${virtualNetworkSpoke::snetClusterNodes.id}'
+]
 output appGwPublicIpAddress string = pipPrimaryClusterIp.id


### PR DESCRIPTION
I was getting a validation error when deploying a regional hub - as the `nodepoolSubnetResourceIds` parameter in the `hub-regionA.bicep` file is expecting an array, but was getting a string