### PR TITLE
Narrowing NSG Source for AppGw ControlPlane traffic

### DIFF
--- a/networking/spoke-BU0001A0008.bicep
+++ b/networking/spoke-BU0001A0008.bicep
@@ -147,7 +147,7 @@ resource nsgAppGwSubnet 'Microsoft.Network/networkSecurityGroups@2021-05-01' = {
           description: 'Allow Azure Control Plane in. (https://docs.microsoft.com/azure/application-gateway/configuration-infrastructure#network-security-groups)'
           protocol: '*'
           sourcePortRange: '*'
-          sourceAddressPrefix: '*'
+          sourceAddressPrefix: 'GatewayManager'
           destinationPortRange: '65200-65535'
           destinationAddressPrefix: '*'
           direction: 'Inbound'

--- a/networking/spoke-BU0001A0008.bicep
+++ b/networking/spoke-BU0001A0008.bicep
@@ -163,7 +163,7 @@ resource nsgAppGwSubnet 'Microsoft.Network/networkSecurityGroups@2021-05-01' = {
           sourcePortRange: '*'
           sourceAddressPrefix: 'AzureLoadBalancer'
           destinationPortRange: '*'
-          destinationAddressPrefix: 'VirtualNetwork'
+          destinationAddressPrefix: '*'
           direction: 'Inbound'
           access: 'Allow'
           priority: 120


### PR DESCRIPTION
The NSG rule allows traffic in on ports 65200-65535 from any source. This should be restricted to just Azure Control Plane Management traffic using the ServiceTag `GatewayManager`.

ref: https://docs.microsoft.com/en-us/azure/application-gateway/configuration-infrastructure#network-security-groups