### PR TITLE
Updating treafik

### DIFF
--- a/07-bootstrap-validation.md
+++ b/07-bootstrap-validation.md
@@ -10,7 +10,7 @@ GitOps allows a team to author Kubernetes manifest files, persist them in their 
 * AAD Pod Identity
 * the workload's namespace named `a0008`
 
-1. Install `kubectl` 1.23 or newer. (`kubectl` supports ±1 Kubernetes version.)
+1. Install `kubectl` 1.24 or newer. (`kubectl` supports ±1 Kubernetes version.)
 
    ```bash
    sudo az aks install-cli

--- a/09-secret-management-and-ingress-controller.md
+++ b/09-secret-management-and-ingress-controller.md
@@ -86,7 +86,7 @@ Previously you have configured [workload prerequisites](./08-workload-prerequisi
 
    ```bash
    # Import ingress controller image hosted in public container registries
-   az acr import --source docker.io/library/traefik:v2.5.3 -n $ACR_NAME_AKS_BASELINE
+   az acr import --source docker.io/library/traefik:v2.8.1 -n $ACR_NAME_AKS_BASELINE
    ```
 
 1. Install the Traefik Ingress Controller.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Finally, this implementation uses the [ASP.NET Core Docker sample web app](https
 
 #### Azure platform
 
-- AKS v1.23
+- AKS v1.24
   - System and User [node pool separation](https://docs.microsoft.com/azure/aks/use-system-pools)
   - [AKS-managed Azure AD](https://docs.microsoft.com/azure/aks/managed-aad)
   - Azure AD-backed Kubernetes RBAC (_local user accounts disabled_)

--- a/workload/traefik.yaml
+++ b/workload/traefik.yaml
@@ -227,10 +227,10 @@ spec:
         # PRODUCTION READINESS CHANGE REQUIRED
         # This image should be sourced from a non-public container registry, such as the
         # one deployed along side of this reference implementation.
-        # az acr import --source docker.io/library/traefik:v2.5.3 -n <your-acr-instance-name>
+        # az acr import --source docker.io/library/traefik:v2.8.1 -n <your-acr-instance-name>
         # and then set this to
-        # image: <your-acr-instance-name>.azurecr.io/library/traefik:v2.5.3
-      - image: docker.io/library/traefik:v2.5.3
+        # image: <your-acr-instance-name>.azurecr.io/library/traefik:v2.8.1
+      - image: docker.io/library/traefik:v2.8.1
         name: traefik-ingress-controller
         resources:
           requests:


### PR DESCRIPTION
Information about how to migrate versions, from this title on:
https://doc.traefik.io/traefik/migration/v2/#v253-to-v254

It doesn't impact our implementation based on the documentation, and after changing files, the deploy was correct.

![image](https://user-images.githubusercontent.com/62260324/184205565-de767f20-1be4-400a-b144-9830f7de4f6b.png)

_Note:_ It was added some AKS version documentation update
