### PR TITLE
Fix retry interval - portal and logs get angry with null

### DIFF
--- a/cluster-stamp.bicep
+++ b/cluster-stamp.bicep
@@ -2013,7 +2013,7 @@ resource mc_fluxConfiguration 'Microsoft.KubernetesConfiguration/fluxConfigurati
         dependsOn: []
         timeoutInSeconds: 300
         syncIntervalInSeconds: 300
-        retryIntervalInSeconds: null
+        retryIntervalInSeconds: 300
         prune: true
         force: false
       }


### PR DESCRIPTION
null technically defaults to the sync interval, but portal doesn't like it and the logs throw needless messages without it.  Setting to 300 (5 minutes)