### PR TITLE
fixed the outdated AKS version for eastus2

### DIFF
--- a/cluster-stamp.bicep
+++ b/cluster-stamp.bicep
@@ -43,7 +43,7 @@ param clusterAuthorizedIPRanges array = []
   'southeastasia'
 ])
 param location string = 'eastus2'
-param kubernetesVersion string = '1.25.2'
+param kubernetesVersion string = '1.25.5'
 
 @description('Domain name to use for App Gateway and AKS ingress.')
 param domainName string = 'contoso.com'


### PR DESCRIPTION
the current latest supported version is 1.25.5. Version 1.25.2 specified in this template is outdated and is not supported. You get the following message if you try to deploy it: 

Inner Errors:
{"code": "AgentPoolK8sVersionNotSupported", "message": "Provisioning of resource(s) for container service aks-66o25hx5ah3mu in resource group rg-bu0001a0008 failed. Message: Version 1.25.2 is not supported in this region. Please use [az aks get-versions] command to get the supported version list in this region. For more information, please check https://aka.ms/supported-version-list. Details: "}

{
      "default": null,
      "isPreview": null,
      "orchestratorType": "Kubernetes",
      "orchestratorVersion": "1.25.5",
      "upgrades": null
    }