### PR TITLE
Fixes "Warning simplify-json-null: Simplify json('null') to null" war…

### DIFF
--- a/cluster-stamp.bicep
+++ b/cluster-stamp.bicep
@@ -1770,7 +1770,7 @@ resource mc 'Microsoft.ContainerService/managedClusters@2023-02-02-preview' = {
       networkPolicy: 'azure'
       outboundType: 'userDefinedRouting'
       loadBalancerSku: 'standard'
-      loadBalancerProfile: json('null')
+      loadBalancerProfile: null
       serviceCidr: '172.16.0.0/16'
       dnsServiceIP: '172.16.0.10'
     }


### PR DESCRIPTION
I was receiving this warning from Azure CLI during deployment:

```
cluster-stamp.bicep(1773,28) : Warning simplify-json-null: Simplify json('null') to null [https://aka.ms/bicep/linter/simplify-json-null]
```

This pull request fixes the warning.