### PR TITLE
patch (security): [deployment] add secure decorator to x509 private keys

### DIFF
--- a/cluster-stamp.bicep
+++ b/cluster-stamp.bicep
@@ -15,7 +15,7 @@ param a0008NamespaceReaderMicrosoftEntraGroupObjectId string
 @description('Your AKS control plane Cluster API authentication tenant')
 param k8sControlPlaneAuthorizationTenantId string
 
-@description('The certificate data for app gateway TLS termination. It is base64')
+@description('The PFX certificate for app gateway TLS termination. It is base64')
 @secure()
 param appGatewayListenerCertificate string
 
@@ -1451,8 +1451,8 @@ resource kv 'Microsoft.KeyVault/vaults@2021-11-01-preview' = {
     }
   }
 
-  resource kvsGatewayPublicCert 'secrets' = {
-    name: 'gateway-public-cert'
+  resource kvsGatewayExternalCert 'secrets' = {
+    name: 'gateway-external-pfx-cert'
     properties: {
       value: appGatewayListenerCertificate
     }
@@ -2199,7 +2199,7 @@ resource agw 'Microsoft.Network/applicationGateways@2021-05-01' = {
       {
         name: '${agwName}-ssl-certificate'
         properties: {
-          keyVaultSecretId: kv::kvsGatewayPublicCert.properties.secretUri
+          keyVaultSecretId: kv::kvsGatewayExternalCert.properties.secretUri
         }
       }
     ]

--- a/cluster-stamp.bicep
+++ b/cluster-stamp.bicep
@@ -16,6 +16,7 @@ param a0008NamespaceReaderMicrosoftEntraGroupObjectId string
 param k8sControlPlaneAuthorizationTenantId string
 
 @description('The certificate data for app gateway TLS termination. It is base64')
+@secure()
 param appGatewayListenerCertificate string
 
 @description('The Base64 encoded AKS Ingress Controller public certificate (as .crt or .cer) to be stored in Azure Key Vault as secret and referenced by Azure Application Gateway as a trusted root certificate.')


### PR DESCRIPTION
- bugfix: decorate private keys with secure string
- change cert naming convention in bicep

Tested end to end:
<img width="937" alt="image" src="https://github.com/mspnp/aks-baseline/assets/158487/5d59fcfd-48c1-427b-9aef-eb238edd8be1">
