### PR TITLE
Enable zone redundancy on ACR

### DIFF
--- a/acr-stamp.bicep
+++ b/acr-stamp.bicep
@@ -179,7 +179,7 @@ resource acrAks 'Microsoft.ContainerRegistry/registries@2021-09-01' = {
     }
     dataEndpointEnabled: true
     networkRuleBypassOptions: 'AzureServices'
-    zoneRedundancy: 'Disabled' // This Preview feature only supports three regions at this time, and eastus2's paired region (centralus), does not support this. So disabling for now.
+    zoneRedundancy: 'Enabled'
   }
 
   resource acrReplication 'replications@2021-09-01' = {


### PR DESCRIPTION
Now that the Central US region supports availability zones, I believe we can safely make the container registry zone-redundant. This PR removes the previous note that the feature is unavailable.