### PR TITLE
Skip Log Analytics query validation during Bicep deployment

### DIFF
--- a/cluster-stamp.bicep
+++ b/cluster-stamp.bicep
@@ -960,6 +960,7 @@ resource sqrPodFailed 'Microsoft.Insights/scheduledQueryRules@2022-06-15' = {
     ]
     evaluationFrequency: 'PT5M'
     windowSize: 'PT10M'
+    skipQueryValidation: true
     criteria: {
       allOf: [
         {


### PR DESCRIPTION
This PR works around a potential deployment race condition.

We deploy a scheduled query rule to detect failed pods. However, the query references a Kusto table that only exists after Container Insights is deployed and running, which takes an unpredictable amount of time.

To work around deployment failures, the Azure Monitor PG advised skipping query validation.