### PR TITLE
feat (cluster): [monitoring ci] change ContainerLogV2 to basic plan

### DIFF
--- a/workload-team/acr-stamp.bicep
+++ b/workload-team/acr-stamp.bicep
@@ -51,6 +51,17 @@ resource laAks 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
       dailyQuotaGb: -1 // No daily cap (configure alert below if enabled)
     }
   }
+
+  resource containerLogV2 'tables' = {
+    name: 'ContainerLogV2'
+    properties: {
+      totalRetentionInDays: 30
+      plan: 'Basic'
+      schema: {
+        name: 'ContainerLogV2'
+      }
+    }
+  }
 }
 
 // Add a alert rule if the log analytics workspace daily data cap has been reached.


### PR DESCRIPTION
## WHY

we do wanted to experiment with the new `basic` plan that reduce costs when ingesting gibs into log analytics 


## WHAT Change?

- configure `ContainerLogV2` table with basic plan at creation time 

## Test

![image](https://github.com/user-attachments/assets/502732c9-5f43-4467-a224-8110766e118c)

![image](https://github.com/user-attachments/assets/2f1904d3-173e-4ad1-8ed4-dc6e87f5d14d)
![image](https://github.com/user-attachments/assets/8611f094-64f5-4aba-b390-84357d79b8ab)
![image](https://github.com/user-attachments/assets/83d99d1d-bc00-4610-8f5b-4235afd4b1dc)

![image](https://github.com/user-attachments/assets/481f5e1d-cd67-4b49-9c57-74b5565175c4)

![image](https://github.com/user-attachments/assets/24519354-8367-48ba-9564-66364f4a5ad6)

![image](https://github.com/user-attachments/assets/4606a2c5-9e8b-498e-b8ce-a2ea99bec56a)




closes: #319587

