### PR TITLE
feat (monitoring): [logs-collection] use DCR instead of ConfigMaps for data collection cfg

### DIFF
--- a/cluster-manifests/kube-system/container-azm-ms-agentconfig.yaml
+++ b/cluster-manifests/kube-system/container-azm-ms-agentconfig.yaml
@@ -12,46 +12,46 @@ data:
   config-version:
     #string.used by customer to keep track of this config file's version in their source control/repository (max allowed 10 chars, other chars will be truncated)
     ver1
-  log-data-collection-settings: |-
+  # log-data-collection-settings: |-
     # Log data collection settings
     # Any errors related to config map settings can be found in the KubeMonAgentEvents table in the Log Analytics workspace that the cluster is sending data to.
 
-    [log_collection_settings]
-       [log_collection_settings.stdout]
+    # [log_collection_settings]
+       # [log_collection_settings.stdout]
           # In the absense of this configmap, default value for enabled is true
-          enabled = true
+          # enabled = true
           # exclude_namespaces setting holds good only if enabled is set to true
           # kube-system,gatekeeper-system log collection are disabled by default in the absence of 'log_collection_settings.stdout' setting. If you want to enable kube-system,gatekeeper-system, remove them from the following setting.
           # If you want to continue to disable kube-system,gatekeeper-system log collection keep the namespaces in the following setting and add any other namespace you want to disable log collection to the array.
           # In the absense of this configmap, default value for exclude_namespaces = ["kube-system","gatekeeper-system"]
-          exclude_namespaces = ["kube-system","gatekeeper-system"]
+          # exclude_namespaces = ["kube-system","gatekeeper-system"]
 
-       [log_collection_settings.stderr]
+       # [log_collection_settings.stderr]
           # Default value for enabled is true
-          enabled = true
+          # enabled = true
           # exclude_namespaces setting holds good only if enabled is set to true
           # kube-system,gatekeeper-system log collection are disabled by default in the absence of 'log_collection_settings.stderr' setting. If you want to enable kube-system,gatekeeper-system, remove them from the following setting.
           # If you want to continue to disable kube-system,gatekeeper-system log collection keep the namespaces in the following setting and add any other namespace you want to disable log collection to the array.
           # In the absense of this configmap, default value for exclude_namespaces = ["kube-system","gatekeeper-system"]
           exclude_namespaces = ["kube-system","gatekeeper-system"]
 
-       [log_collection_settings.env_var]
+       # [log_collection_settings.env_var]
           # In the absense of this configmap, default value for enabled is true
-          enabled = true
-       [log_collection_settings.enrich_container_logs]
+          # enabled = true
+       # [log_collection_settings.enrich_container_logs]
           # In the absense of this configmap, default value for enrich_container_logs is false
-          enabled = false
+          # enabled = false
           # When this is enabled (enabled = true), every container log entry (both stdout & stderr) will be enriched with container Name & container Image
-       [log_collection_settings.collect_all_kube_events]
+       # [log_collection_settings.collect_all_kube_events]
           # In the absense of this configmap, default value for collect_all_kube_events is false
           # When the setting is set to false, only the kube events with !normal event type will be collected
-          enabled = false
+          # enabled = false
           # When this is enabled (enabled = true), all kube events including normal events will be collected
-       [log_collection_settings.schema]
+       # [log_collection_settings.schema]
           # In the absence of this configmap, default value for containerlog_schema_version is "v1"
           # Supported values for this setting are "v1","v2"
           # See documentation at https://aka.ms/ContainerLogv2 for benefits of v2 schema over v1 schema before opting for "v2" schema
-          containerlog_schema_version = "v2"
+          # containerlog_schema_version = "v2"
        #[log_collection_settings.enable_multiline_logs]
           # fluent-bit based multiline log collection for go (stacktrace), dotnet (stacktrace)
           # if enabled will also stitch together container logs split by docker/cri due to size limits(16KB per log line)
@@ -116,13 +116,13 @@ data:
 
         #fielddrop = ["metric_to_drop"]
 
-  metric_collection_settings: |-
+  # metric_collection_settings: |-
     # Metrics collection settings for metrics sent to Log Analytics and MDM
-    [metric_collection_settings.collect_kube_system_pv_metrics]
+    # [metric_collection_settings.collect_kube_system_pv_metrics]
       # In the absense of this configmap, default value for collect_kube_system_pv_metrics is false
       # When the setting is set to false, only the persistent volume metrics outside the kube-system namespace will be collected
       # When this is enabled (enabled = true), persistent volume metrics including those in the kube-system namespace will be collected
-      enabled = true
+      # enabled = true
 
   alertable-metrics-configuration-settings: |-
     # Alertable metrics configuration settings for container resource utilization

--- a/cluster-manifests/kube-system/container-azm-ms-agentconfig.yaml
+++ b/cluster-manifests/kube-system/container-azm-ms-agentconfig.yaml
@@ -33,7 +33,7 @@ data:
           # kube-system,gatekeeper-system log collection are disabled by default in the absence of 'log_collection_settings.stderr' setting. If you want to enable kube-system,gatekeeper-system, remove them from the following setting.
           # If you want to continue to disable kube-system,gatekeeper-system log collection keep the namespaces in the following setting and add any other namespace you want to disable log collection to the array.
           # In the absense of this configmap, default value for exclude_namespaces = ["kube-system","gatekeeper-system"]
-          exclude_namespaces = ["kube-system","gatekeeper-system"]
+          # exclude_namespaces = ["kube-system","gatekeeper-system"]
 
        # [log_collection_settings.env_var]
           # In the absense of this configmap, default value for enabled is true

--- a/workload-team/cluster-stamp.bicep
+++ b/workload-team/cluster-stamp.bicep
@@ -283,14 +283,7 @@ resource dcrContainerInsights 'Microsoft.Insights/dataCollectionRules@2023-03-11
             'uucp'
           ]
           logLevels: [
-            // 'Debug'
             'Info'
-            // 'Notice'
-            // 'Warning'
-            // 'Error'
-            // 'Critical'
-            // 'Alert'
-            // 'Emergency'
           ]
         }
       ]

--- a/workload-team/cluster-stamp.bicep
+++ b/workload-team/cluster-stamp.bicep
@@ -291,7 +291,6 @@ resource dcrContainerInsights 'Microsoft.Insights/dataCollectionRules@2023-03-11
         {
           name: 'ContainerInsightsExtension'
           streams: [
-            //'Microsoft-ContainerLog'
             'Microsoft-ContainerLogV2'
             'Microsoft-KubeEvents'
             'Microsoft-KubePodInventory'
@@ -338,7 +337,6 @@ resource dcrContainerInsights 'Microsoft.Insights/dataCollectionRules@2023-03-11
       }
       {
         streams: [
-          //'Microsoft-ContainerLog'
           'Microsoft-ContainerLogV2'
           'Microsoft-KubeEvents'
           'Microsoft-KubePodInventory'

--- a/workload-team/cluster-stamp.bicep
+++ b/workload-team/cluster-stamp.bicep
@@ -258,7 +258,7 @@ resource dcrContainerInsights 'Microsoft.Insights/dataCollectionRules@2023-03-11
         {
           name: 'ContainerInsightsExtension'
           streams: [
-            'Microsoft-ContainerLog'
+            'Microsoft-ContainerLogV2'
             'Microsoft-KubeEvents'
             'Microsoft-KubePodInventory'
             'Microsoft-KubeNodeInventory'
@@ -278,7 +278,7 @@ resource dcrContainerInsights 'Microsoft.Insights/dataCollectionRules@2023-03-11
                 'kube-system'
                 'gatekeeper-system'
               ]
-              enableContainerLogV2: false
+              enableContainerLogV2: true
             }
           }
           extensionName: 'ContainerInsights'

--- a/workload-team/cluster-stamp.bicep
+++ b/workload-team/cluster-stamp.bicep
@@ -258,6 +258,7 @@ resource dcrContainerInsights 'Microsoft.Insights/dataCollectionRules@2023-03-11
         {
           name: 'ContainerInsightsExtension'
           streams: [
+            //'Microsoft-ContainerLog'
             'Microsoft-ContainerLogV2'
             'Microsoft-KubeEvents'
             'Microsoft-KubePodInventory'
@@ -296,7 +297,8 @@ resource dcrContainerInsights 'Microsoft.Insights/dataCollectionRules@2023-03-11
     dataFlows: [
       {
         streams: [
-          'Microsoft-ContainerLog'
+          //'Microsoft-ContainerLog'
+          'Microsoft-ContainerLogV2'
           'Microsoft-KubeEvents'
           'Microsoft-KubePodInventory'
           'Microsoft-KubeNodeInventory'

--- a/workload-team/cluster-stamp.bicep
+++ b/workload-team/cluster-stamp.bicep
@@ -254,6 +254,46 @@ resource dcrContainerInsights 'Microsoft.Insights/dataCollectionRules@2023-03-11
 
   properties: {
     dataSources: {
+      syslog: [
+        {
+          name: 'sysLogsDataSource'
+          streams: [
+            'Microsoft-Syslog'
+          ]
+          facilityNames: [
+            'auth'
+            'authpriv'
+            'cron'
+            'daemon'
+            'mark'
+            'kern'
+            'local0'
+            'local1'
+            'local2'
+            'local3'
+            'local4'
+            'local5'
+            'local6'
+            'local7'
+            'lpr'
+            'mail'
+            'news'
+            'syslog'
+            'user'
+            'uucp'
+          ]
+          logLevels: [
+            // 'Debug'
+            'Info'
+            // 'Notice'
+            // 'Warning'
+            // 'Error'
+            // 'Critical'
+            // 'Alert'
+            // 'Emergency'
+          ]
+        }
+      ]
       extensions: [
         {
           name: 'ContainerInsightsExtension'
@@ -295,6 +335,14 @@ resource dcrContainerInsights 'Microsoft.Insights/dataCollectionRules@2023-03-11
       ]
     }
     dataFlows: [
+      {
+        streams: [
+          'Microsoft-Syslog'
+        ]
+        destinations: [
+          la.name
+        ]
+      }
       {
         streams: [
           //'Microsoft-ContainerLog'

--- a/workload-team/cluster-stamp.bicep
+++ b/workload-team/cluster-stamp.bicep
@@ -248,7 +248,7 @@ resource dcrAssociation 'Microsoft.Insights/dataCollectionRuleAssociations@2023-
 
 // A data collection rule that collects ContainerInsights logs from pods, nodes and cluster and configure Azure Log Analytics workspace as destination
 resource dcrContainerInsights 'Microsoft.Insights/dataCollectionRules@2023-03-11' = {
-  name: 'MSCI-${location}-${clusterName}'
+  name: 'MSCI-${location}-${mc.name}'
   kind: 'Linux'
   location: location
 
@@ -903,7 +903,6 @@ resource mc 'Microsoft.ContainerService/managedClusters@2024-03-02-preview' = {
     policies
 
     dcr
-    dcrContainerInsights
 
     peKv
     kvPodMiIngressControllerKeyVaultReader_roleAssignment

--- a/workload-team/cluster-stamp.bicep
+++ b/workload-team/cluster-stamp.bicep
@@ -783,6 +783,7 @@ resource mc 'Microsoft.ContainerService/managedClusters@2024-03-02-preview' = {
         enabled: true
         config: {
           logAnalyticsWorkspaceResourceId: la.id
+          useAADAuth: 'true'
         }
       }
       aciConnectorLinux: {
@@ -983,17 +984,6 @@ resource acrKubeletAcrPullRole_roleAssignment 'Microsoft.Authorization/roleAssig
     roleDefinitionId: acrPullRole.id
     description: 'Allows AKS to pull container images from this ACR instance.'
     principalId: mc.properties.identityProfile.kubeletidentity.objectId
-    principalType: 'ServicePrincipal'
-  }
-}
-
-// Grant the Azure Monitor (fka as OMS) Agent's Managed Identity the metrics publisher role to push alerts
-resource mcAmaAgentMonitoringMetricsPublisherRole_roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  scope: mc
-  name: guid(mc.id, 'amagent', monitoringMetricsPublisherRole.id)
-  properties: {
-    roleDefinitionId: monitoringMetricsPublisherRole.id
-    principalId: mc.properties.addonProfiles.omsagent.identity.objectId
     principalType: 'ServicePrincipal'
   }
 }


### PR DESCRIPTION
## WHY?

We do wanted to switch from k8s single cluster configmap CI log collection configuration to DCR as this can be shared by multiple clusters and provide with a more control plane experience. Additionally, it is aligned on how we started collecting Prometheus metrics from previous release delivering a more consistent method (now for logs) for configuration of different data sources.

## WHAT?

- comment out log data collection from `Monitor agent` configmap
- [enable CI data collection using DCR](https://learn.microsoft.com/azure/azure-monitor/containers/container-insights-data-collection-configure?tabs=arm#configure-data-collection-using-dcr). Data sent to LA is expected to be equivalent or similar
- enable `ContainerLogV2` schema feature via [DCR instead of ConfigMaps](https://learn.microsoft.com/azure/azure-monitor/containers/container-insights-logs-schema#enable-the-containerlogv2-schema)

## Test

#### Configuring Monitoring Settings using ContainerInsights DCR extension settings
![image](https://github.com/user-attachments/assets/df966f56-1d8b-49bd-9987-39d79f3e6242)
![image](https://github.com/user-attachments/assets/fbc8d993-1567-45fd-85e6-4ed89e1047d6)

#### New DCR for SCI
![image](https://github.com/user-attachments/assets/b2b30cf6-db38-435f-979f-d3bd02b46edb)

#### New DCR resource ask cluster association (DCRA)
![image](https://github.com/user-attachments/assets/99feaf46-1e2d-4fb5-b550-d19e688b32c8)

#### ContainerLogV2 enabled and ingesting logs
![image](https://github.com/user-attachments/assets/43baf962-c278-4f77-b7c1-4c6fd2a8a782)


closes: #308593