### PR TITLE
feat (infra): [network] disable default outbound access

### DIFF
--- a/network-team/hub-default.bicep
+++ b/network-team/hub-default.bicep
@@ -292,18 +292,21 @@ resource vnetHub 'Microsoft.Network/virtualNetworks@2023-11-01' = {
       {
         name: 'AzureFirewallSubnet'
         properties: {
+          defaultOutboundAccess: false
           addressPrefix: hubVirtualNetworkAzureFirewallSubnetAddressSpace
         }
       }
       {
         name: 'GatewaySubnet'
         properties: {
+          defaultOutboundAccess: false
           addressPrefix: hubVirtualNetworkGatewaySubnetAddressSpace
         }
       }
       {
         name: 'AzureBastionSubnet'
         properties: {
+          defaultOutboundAccess: false
           addressPrefix: hubVirtualNetworkBastionSubnetAddressSpace
           networkSecurityGroup: {
             id: nsgBastionSubnet.id

--- a/network-team/hub-regionA.bicep
+++ b/network-team/hub-regionA.bicep
@@ -296,18 +296,21 @@ resource vnetHub 'Microsoft.Network/virtualNetworks@2023-11-01' = {
       {
         name: 'AzureFirewallSubnet'
         properties: {
+          defaultOutboundAccess: false
           addressPrefix: hubVirtualNetworkAzureFirewallSubnetAddressSpace
         }
       }
       {
         name: 'GatewaySubnet'
         properties: {
+          defaultOutboundAccess: false
           addressPrefix: hubVirtualNetworkGatewaySubnetAddressSpace
         }
       }
       {
         name: 'AzureBastionSubnet'
         properties: {
+          defaultOutboundAccess: false
           addressPrefix: hubVirtualNetworkBastionSubnetAddressSpace
           networkSecurityGroup: {
             id: nsgBastionSubnet.id

--- a/network-team/spoke-BU0001A0008.bicep
+++ b/network-team/spoke-BU0001A0008.bicep
@@ -325,6 +325,7 @@ resource vnetSpoke 'Microsoft.Network/virtualNetworks@2023-11-01' = {
       {
         name: 'snet-clusternodes'
         properties: {
+          defaultOutboundAccess: false
           addressPrefix: '10.240.0.0/22'
           routeTable: {
             id: routeNextHopToFirewall.id
@@ -339,6 +340,7 @@ resource vnetSpoke 'Microsoft.Network/virtualNetworks@2023-11-01' = {
       {
         name: 'snet-clusteringressservices'
         properties: {
+          defaultOutboundAccess: false
           addressPrefix: '10.240.4.0/28'
           routeTable: {
             id: routeNextHopToFirewall.id

--- a/network-team/spoke-BU0001A0008.bicep
+++ b/network-team/spoke-BU0001A0008.bicep
@@ -355,6 +355,7 @@ resource vnetSpoke 'Microsoft.Network/virtualNetworks@2023-11-01' = {
       {
         name: 'snet-applicationgateway'
         properties: {
+          defaultOutboundAccess: false
           addressPrefix: '10.240.5.0/24'
           networkSecurityGroup: {
             id: nsgAppGwSubnet.id
@@ -366,6 +367,7 @@ resource vnetSpoke 'Microsoft.Network/virtualNetworks@2023-11-01' = {
       {
         name: 'snet-privatelinkendpoints'
         properties: {
+          defaultOutboundAccess: false
           addressPrefix: '10.240.4.32/28'
           networkSecurityGroup: {
             id: nsgPrivateLinkEndpointsSubnet.id


### PR DESCRIPTION
## WHY

we wanted to explicitly disable outbound access, means no default outbound access for all subnet except those delegated or managed. We wanted to ensure that baseline is working enforcing this setup since default access is being retired in September

## WHAT Changed

- `firewall`, `gateway`, `bastion`, `appgw`, `privateendpoints`, `cluster-nodes` and `ingress` subnets are now marked with default outbound access as `false` 

## TEST

<img width="951" height="641" alt="image" src="https://github.com/user-attachments/assets/739c6d20-0eb1-416f-a82e-c296469b3cc5" />

hub

<img width="216" height="235" alt="image" src="https://github.com/user-attachments/assets/fbfed2e8-a8bf-4c0e-a3ae-22a063f7bcc7" />

spoke
<img width="246" height="302" alt="image" src="https://github.com/user-attachments/assets/5587cfda-4f1a-401a-bb8d-7eb899cfecba" />

